### PR TITLE
read images faster

### DIFF
--- a/rsciio/phenom/_api.py
+++ b/rsciio/phenom/_api.py
@@ -788,6 +788,7 @@ class ElidReader:
         )
 
     def _read_MapAnalysis(self, label, am):
+        print("reading map analysis")
         (om, sum_spectrum) = self._read_CommonAnalysis(am)
         # These metadata are currently not used but we still need to
         # read these to advance the position in the file
@@ -814,10 +815,22 @@ class ElidReader:
         has_variable_real_time = self._read_bool()
         has_variable_live_time = self._read_bool()
         data = np.empty([height, width, bins], dtype=np.uint32)
-        for y in range(height):
-            for x in range(width):
-                for bin in range(bins):
-                    data[y, x, bin] = self._read_varuint32()
+        print("bins", bins)
+        print("start read bytes")
+        # for y in range(height):
+        #     # for x in range(width):
+        #     #     # for bin in range(bins):
+        #     #     #     data[y, x, bin] = self._read_varuint32()
+        #     #     data[y, x, :] = struct.unpack(f"{bins}B", self._read(bins))
+        #     data[y, :, :] = np.array(
+        #         struct.unpack(f"{width * bins}B", self._read(width * bins))
+        #     ).reshape(width, bins)
+        data = np.array(
+            struct.unpack(
+                f"{height * width * bins}B", self._read(height * width * bins)
+            )
+        ).reshape(height, width, bins)
+        print("end read bytes")
         if has_variable_real_time:
             real_time_values = np.empty([height, width], dtype=float)
             for y in range(height):

--- a/rsciio/phenom/_api.py
+++ b/rsciio/phenom/_api.py
@@ -815,22 +815,15 @@ class ElidReader:
         has_variable_real_time = self._read_bool()
         has_variable_live_time = self._read_bool()
         data = np.empty([height, width, bins], dtype=np.uint32)
-        print("bins", bins)
-        print("start read bytes")
-        # for y in range(height):
-        #     # for x in range(width):
-        #     #     # for bin in range(bins):
-        #     #     #     data[y, x, bin] = self._read_varuint32()
-        #     #     data[y, x, :] = struct.unpack(f"{bins}B", self._read(bins))
-        #     data[y, :, :] = np.array(
-        #         struct.unpack(f"{width * bins}B", self._read(width * bins))
-        #     ).reshape(width, bins)
-        data = np.array(
-            struct.unpack(
-                f"{height * width * bins}B", self._read(height * width * bins)
-            )
-        ).reshape(height, width, bins)
-        print("end read bytes")
+        for y in range(height):
+            data[y, :, :] = np.array(
+                struct.unpack(f"{width * bins}B", self._read(width * bins))
+            ).reshape(width, bins)
+        # data = np.array(
+        #     struct.unpack(
+        #         f"{height * width * bins}B", self._read(height * width * bins)
+        #     )
+        # ).reshape(height, width, bins)
         if has_variable_real_time:
             real_time_values = np.empty([height, width], dtype=float)
             for y in range(height):

--- a/rsciio/phenom/_api.py
+++ b/rsciio/phenom/_api.py
@@ -788,7 +788,6 @@ class ElidReader:
         )
 
     def _read_MapAnalysis(self, label, am):
-        print("reading map analysis")
         (om, sum_spectrum) = self._read_CommonAnalysis(am)
         # These metadata are currently not used but we still need to
         # read these to advance the position in the file
@@ -814,16 +813,12 @@ class ElidReader:
         original_metadata["acquisition"]["scan"]["detectors"]["EDS"] = eds_metadata
         has_variable_real_time = self._read_bool()
         has_variable_live_time = self._read_bool()
-        data = np.empty([height, width, bins], dtype=np.uint32)
-        for y in range(height):
-            data[y, :, :] = np.array(
-                struct.unpack(f"{width * bins}B", self._read(width * bins))
-            ).reshape(width, bins)
-        # data = np.array(
-        #     struct.unpack(
-        #         f"{height * width * bins}B", self._read(height * width * bins)
-        #     )
-        # ).reshape(height, width, bins)
+        buffer = self._read(height * width * bins)
+        data = (
+            np.frombuffer(buffer, dtype=np.uint8)
+            .reshape(height, width, bins)
+            .astype(np.uint32)
+        )
         if has_variable_real_time:
             real_time_values = np.empty([height, width], dtype=float)
             for y in range(height):


### PR DESCRIPTION
### Description of the change
Read `.elid` files much faster since we bulk read bytes at a time (not reading it one byte at a time, which for our images would've taken 295,895,040 iterations)

On one image (RAI-11/RAI-11_BR.elid) it went from 740.8860 seconds to 11.270040035247803 seconds (65.7394293x faster)